### PR TITLE
fix broken link

### DIFF
--- a/examples/join_and_relationalize.md
+++ b/examples/join_and_relationalize.md
@@ -38,7 +38,7 @@ This is a semi-normalized collection of tables containing legislators and their 
 
 The easiest way to debug your pySpark ETL scripts is to create a `DevEndpoint'
 and run your code there.  You can do this in the AWS Glue console, as described
-[here in the Developer Guide](http://docs.aws.amazon.com/glue/latest/dg/tutorial-development-endpoint-notebook.html).
+[here in the Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/dev-endpoint-tutorial-prerequisites.html). Make sure to follow instruction under section "Creating a Development Endpoint with a VPC".
 
 ### 3. Getting started
 


### PR DESCRIPTION
old link: http://docs.aws.amazon.com/glue/latest/dg/tutorial-development-endpoint-notebook.html
new link: https://docs.aws.amazon.com/glue/latest/dg/dev-endpoint-tutorial-prerequisites.html

added extra wording to make sure readers use endpoint with VPC.