### PR TITLE
Fixed broken validation for some regions

### DIFF
--- a/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
+++ b/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
@@ -1471,7 +1471,7 @@ def validate_aws_regions(region):
         return
 
     aws_glue_regions = [
-        'ap-northeast-1' # Tokyo
+        'ap-northeast-1', # Tokyo
         'eu-west-1', # Ireland
         'us-east-1', # North Virginia
         'us-east-2', # Ohio


### PR DESCRIPTION
*Issue #, if available:*
aws_glue_regions definition was incorrect.
Validation wont work for 'ap-northeast-1' and 'eu-west-1'

*Description of changes:*
Fixed array definition

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
