### PR TITLE
upgrade httpclient version.

### DIFF
--- a/utilities/Spark_UI/Dockerfile
+++ b/utilities/Spark_UI/Dockerfile
@@ -12,6 +12,9 @@ RUN tar -xzf spark-2.4.3-bin-without-hadoop.tgz && \
     rm spark-2.4.3-bin-without-hadoop.tgz
 RUN mvn dependency:copy-dependencies -DoutputDirectory=/opt/spark/jars/
 
+RUN curl -o ./httpclient-4.5.9.jar http://repo.maven.apache.org/maven2/org/apache/httpcomponents/httpclient/4.5.9/httpclient-4.5.9.jar
+RUN mv httpclient-4.5.9.jar /opt/spark/jars/
+
 RUN echo $'\n\
 spark.eventLog.enabled                      true\n\
 spark.history.ui.port                       18080\n\


### PR DESCRIPTION
Hi. I got an error when read and executed the [SPARK_UI REAEME](https://github.com/aws-samples/aws-glue-samples/blob/master/utilities/Spark_UI/README.md)

error are like this.

> 19/12/19 01:28:02 WARN ApacheUtils: NoSuchMethodError was thrown when disabling normalizeUri. This indicates you are using an old version (< 4.5.8) of Apache http client. It is recommended to use http client version >= 4.5.9 to avoid the breaking change introduced in apache client 4.5.7 and the latency in exception handling. See https://github.com/aws/aws-sdk-java/issues/1919 for more information

Read https://github.com/aws/aws-sdk-java/issues/1919 and upgraded httpclient version. Then the error was fixed.

This sample is linked to the steps in the document below.
https://docs.aws.amazon.com/glue/latest/dg/monitor-spark-ui-history.html

I think many Amazon Glue user are in trouble.
