### PR TITLE
Handle errors on permission revoke failures

### DIFF
--- a/utilities/use_only_IAM_access_controls/update_permission.py
+++ b/utilities/use_only_IAM_access_controls/update_permission.py
@@ -105,9 +105,13 @@ while 'NextToken' in res:
 for p in permissions:
     if p['Principal']['DataLakePrincipalIdentifier'] != 'IAM_ALLOWED_PRINCIPALS':
         print('...Revoking permissions of ' + p['Principal']['DataLakePrincipalIdentifier'] + ' on table ' + d['Name'] + '...')
-        lakeformation.revoke_permissions(Principal=p['Principal'],
-                                         Resource=p['Resource'],
-                                         Permissions=p['Permissions'],
-                                         PermissionsWithGrantOption=p['PermissionsWithGrantOption'])
+        try:
+            lakeformation.revoke_permissions(Principal=p['Principal'],
+                                             Resource=p['Resource'],
+                                             Permissions=p['Permissions'],
+                                             PermissionsWithGrantOption=p['PermissionsWithGrantOption'])
+        except Exception as e:
+            print(e)
+
 
 print("Completed!")


### PR DESCRIPTION
Sometimes this script will fail on the last step with the following error which should be ignored (continued)

```An error occurred (InvalidInputException) when calling the RevokePermissions operation: No permissions revoked. Grantee has no permissions and no grantable permissions on resource.```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
