### PR TITLE
Bump up awssdk.version to 1.11.903 to fix  java.lang.NoSuchFieldError

### DIFF
--- a/utilities/Spark_UI/glue-3_0/pom.xml
+++ b/utilities/Spark_UI/glue-3_0/pom.xml
@@ -13,7 +13,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<jdk.version>1.8</jdk.version>
 		<hadoop.version>3.2.1</hadoop.version>
-		<awssdk.version>1.11.901</awssdk.version>
+		<awssdk.version>1.11.903</awssdk.version>
 		<httpclient.version>4.5.13</httpclient.version>
 		<jackson.version>2.10.5</jackson.version>
 		<jackson.databind.version>2.10.5.1</jackson.databind.version>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

With OOTB POM that has <awssdk.version>1.11.901</awssdk.version> I was running into following exception when starting the docker container:

Caused by: java.lang.NoSuchFieldError: SERVICE_ID
	at com.amazonaws.services.s3.AmazonS3Client.createRequest(AmazonS3Client.java:4772)
	at com.amazonaws.services.s3.AmazonS3Client.createRequest(AmazonS3Client.java:4758)
	at com.amazonaws.services.s3.AmazonS3Client.headBucket(AmazonS3Client.java:1434)
	at com.amazonaws.services.s3.AmazonS3Client.doesBucketExist(AmazonS3Client.java:1374)
	at org.apache.hadoop.fs.s3a.S3AFileSystem.lambda$verifyBucketExists$1(S3AFileSystem.java:381)
	at org.apache.hadoop.fs.s3a.Invoker.once(Invoker.java:109)
	at org.apache.hadoop.fs.s3a.Invoker.lambda$retry$3(Invoker.java:265)

With <awssdk.version>1.11.903</awssdk.version> the issue is resolved and I am able start the docker container and view the details of the completed spark jobs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
