### PR TITLE
Make ETL job can work in Glue 2 and Glue3

### DIFF
--- a/utilities/Hive_metastore_migration/src/export_from_datacatalog.py
+++ b/utilities/Hive_metastore_migration/src/export_from_datacatalog.py
@@ -1,5 +1,6 @@
 #  Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: MIT-0
+# Work with Glue 2.0 and Glue 3.0
 
 from __future__ import print_function
 

--- a/utilities/Hive_metastore_migration/src/import_into_datacatalog.py
+++ b/utilities/Hive_metastore_migration/src/import_into_datacatalog.py
@@ -1,12 +1,15 @@
 #  Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: MIT-0
 
+# Work with Glue 2.0 and Glue 3.0
+
 from __future__ import print_function
 
 from awsglue.context import GlueContext
 from awsglue.dynamicframe import DynamicFrame
 
 from hive_metastore_migration import *
+
 
 
 def transform_df_to_catalog_import_schema(sql_context, glue_context, df_databases, df_tables, df_partitions):


### PR DESCRIPTION
*Issue #, if available:*
Original ETL job script fails with Glue 2 and  Glue 3
*Description of changes:*
Make the ETL job work in Glue 2 and Glue3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
