### PR TITLE
Make the Hive Metastore Migration ETL job work with Python3 in Glue 2 and Glue 3

### DIFF
--- a/utilities/Hive_metastore_migration/src/export_from_datacatalog.py
+++ b/utilities/Hive_metastore_migration/src/export_from_datacatalog.py
@@ -1,6 +1,6 @@
 #  Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: MIT-0
-# Work with Glue 2.0 and Glue 3.0
+# Work with Python 3 in Glue 2.0 and Glue 3.0
 
 from __future__ import print_function
 

--- a/utilities/Hive_metastore_migration/src/export_from_datacatalog.py
+++ b/utilities/Hive_metastore_migration/src/export_from_datacatalog.py
@@ -1,5 +1,6 @@
 #  Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: MIT-0
+# Work with Glue 2.0 and Glue 3.0
 
 from __future__ import print_function
 

--- a/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
+++ b/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
@@ -342,7 +342,6 @@ class HiveMetastoreTransformer:
                 del dictionary[None]
             return dictionary
 
-
         id_type = df.get_schema_type(id_col)
         map_type = MapType(keyType=df.get_schema_type(key), valueType=df.get_schema_type(value))
         output_schema = StructType([StructField(name=id_col, dataType=id_type, nullable=False),
@@ -407,8 +406,6 @@ class HiveMetastoreTransformer:
         schema = StructType([StructField(name=id_col, dataType=LongType(), nullable=False),
                              StructField(name=payloads_column_name, dataType=ArrayType(elementType=payload_type))])
         return self.sql_context.createDataFrame(rdd_result, schema)
-
-
 
     def transform_ms_partition_keys(self, ms_partition_keys):
         return self.transform_df_with_idx(df=ms_partition_keys,
@@ -688,7 +685,6 @@ class HiveMetastoreTransformer:
             ('IS_COMPRESSED', 'compressed'),
             ('IS_STOREDASSUBDIRECTORIES', 'storedAsSubDirectories')
         ])
-
 
         storage_descriptors_with_empty_sorted_cols = HiveMetastoreTransformer.fill_none_with_empty_list(
             storage_descriptors_renamed, 'sortColumns')

--- a/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
+++ b/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
@@ -289,11 +289,6 @@ def register_methods_to_dataframe():
         DataFrame.rename_columns = rename_columns_for_class
         DataFrame.get_schema_type = get_schema_type_for_class
         DataFrame.join_other_to_single_column = join_other_to_single_column
-        # DataFrame.empty = MethodType(empty, DataFrame)
-        # DataFrame.drop_columns = MethodType(drop_columns, DataFrame)
-        # DataFrame.rename_columns = MethodType(rename_columns, DataFrame)
-        # DataFrame.get_schema_type = MethodType(get_schema_type, DataFrame)
-        # DataFrame.join_other_to_single_column = MethodType(join_other_to_single_column, DataFrame)
     else:
         DataFrame.empty = MethodType(empty, None, DataFrame)
         DataFrame.drop_columns = MethodType(drop_columns, None, DataFrame)
@@ -351,7 +346,6 @@ class HiveMetastoreTransformer:
             df.rdd.map(lambda row: (row[id_col], {row[key]: row[value]})).reduceByKey(merge_dict).map(
                 lambda rec: (rec[0], remove_none_key(rec[1]))), output_schema)
 
-    #lambda id_name, dictionary: (id_name, remove_none_key(dictionary))), output_schema)
 
     def join_with_params(self, df, df_params, id_col):
         df_params_map = self.transform_params(params_df=df_params, id_col=id_col)
@@ -399,9 +393,6 @@ class HiveMetastoreTransformer:
             .aggregateByKey([], append, extend) \
             .map(lambda rec: (rec[0], sorted(rec[1], key=lambda t: t[0]))) \
             .map(lambda rec: (rec[0], [payload for index, payload in rec[1]]))
-
-        # .map(lambda id_column, list_with_idx: (id_column, sorted(list_with_idx, key=lambda t: t[0]))) \
-        # .map(lambda id_column, list_with_idx: (id_column, [payload for index, payload in list_with_idx]))
 
         schema = StructType([StructField(name=id_col, dataType=LongType(), nullable=False),
                              StructField(name=payloads_column_name, dataType=ArrayType(elementType=payload_type))])

--- a/utilities/Hive_metastore_migration/src/import_into_datacatalog.py
+++ b/utilities/Hive_metastore_migration/src/import_into_datacatalog.py
@@ -1,7 +1,7 @@
 #  Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: MIT-0
 
-# Work with Glue 2.0 and Glue 3.0
+# Work with Python 3 in Glue 2.0 and Glue 3.0
 
 from __future__ import print_function
 
@@ -9,7 +9,6 @@ from awsglue.context import GlueContext
 from awsglue.dynamicframe import DynamicFrame
 
 from hive_metastore_migration import *
-
 
 
 def transform_df_to_catalog_import_schema(sql_context, glue_context, df_databases, df_tables, df_partitions):

--- a/utilities/Hive_metastore_migration/src/import_into_datacatalog.py
+++ b/utilities/Hive_metastore_migration/src/import_into_datacatalog.py
@@ -1,12 +1,15 @@
 #  Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #  SPDX-License-Identifier: MIT-0
 
+# Work with Glue 2.0 and Glue 3.0
+
 from __future__ import print_function
 
 from awsglue.context import GlueContext
 from awsglue.dynamicframe import DynamicFrame
 
 from hive_metastore_migration import *
+
 
 
 def transform_df_to_catalog_import_schema(sql_context, glue_context, df_databases, df_tables, df_partitions):

--- a/utilities/Hive_metastore_migration/src/import_into_datacatalog.py
+++ b/utilities/Hive_metastore_migration/src/import_into_datacatalog.py
@@ -2,7 +2,6 @@
 #  SPDX-License-Identifier: MIT-0
 
 # Work with Python 3 in Glue 2.0 and Glue 3.0
-
 from __future__ import print_function
 
 from awsglue.context import GlueContext


### PR DESCRIPTION
This pull request is to make the Hive Metastore Migration ETL job compatible with Python 3 on Glue 2.0 and Glue 3.0.

*Description of the issue:*
Original ETL job script had the following error with Python 3 in Glue 2 and Glue 3:

```
2022-05-07 09:08:18,037 ERROR [main] glue.ProcessLauncher (Logging.scala:logError(70)): Error from Python:Traceback (most recent call last):
  File “/tmp/import_into_datacatalog.py”, line 130, in <module>
    main()
  File “/tmp/import_into_datacatalog.py”, line 126, in main
    region=options.get(‘region’) or ‘us-east-1’
  File “/tmp/import_into_datacatalog.py”, line 51, in metastore_full_migration
    sc, sql_context, db_prefix, table_prefix).transform(hive_metastore)
  File “/tmp/localPyFiles-2f7485a4-1b85-49e8-881e-ab0046592867/hive_metastore_migration.py”, line 753, in transform
    ms_database_params=[hive_metastore.ms](http://hive_metastore.ms/)_database_params)
  File “/tmp/localPyFiles-2f7485a4-1b85-49e8-881e-ab0046592867/hive_metastore_migration.py”, line 734, in transform_databases
    dbs_with_params = self.join_with_params(df=ms_dbs, df_params=ms_database_params, id_col=‘DB_ID’)
  File “/tmp/localPyFiles-2f7485a4-1b85-49e8-881e-ab0046592867/hive_metastore_migration.py”, line 336, in join_with_params
    df_params_map = self.transform_params(params_df=df_params, id_col=id_col)
  File “/tmp/localPyFiles-2f7485a4-1b85-49e8-881e-ab0046592867/hive_metastore_migration.py”, line 314, in transform_params
    return self.kv_pair_to_map(params_df, id_col, key, value, ‘parameters’)
  File “/tmp/localPyFiles-2f7485a4-1b85-49e8-881e-ab0046592867/hive_metastore_migration.py”, line 326, in kv_pair_to_map
    id_type = df.get_schema_type(id_col)
  File “/tmp/localPyFiles-2f7485a4-1b85-49e8-881e-ab0046592867/hive_metastore_migration.py”, line 199, in get_schema_type
    return df.select(column_name).schema.fields[0].dataType
  File “/opt/amazon/spark/python/lib/pyspark.zip/pyspark/sql/dataframe.py”, line 1320, in select
    jdf = self._jdf.select(self._jcols(*cols))
AttributeError: ‘str’ object has no attribute ‘_jdf’
```

*Description of changes:*
The root cause cause of above error is that we used dynamic method (`MethodType`) in the ETL script, for example Line 287 in the new file. Some of the methods are used either by direct method call or `MethodType`. However for Python 3, dynamic method for class is different with direct method call. We made a change to create different method for different scenario to make it available on Python 3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
