### PR TITLE
support s3 bucket name with dot

### DIFF
--- a/utilities/Spark_UI/glue-4_0/Dockerfile
+++ b/utilities/Spark_UI/glue-4_0/Dockerfile
@@ -22,8 +22,9 @@ RUN rm /opt/spark/jars/jsr305-3.0.0.jar && \
     rm /opt/spark/jars/ion-java-1.0.2.jar
 
 RUN echo $'\n\
-spark.eventLog.enabled                      true\n\
-spark.history.ui.port                       18080\n\
-' > /opt/spark/conf/spark-defaults.conf
+    spark.eventLog.enabled                      true\n\
+    spark.history.ui.port                       18080\n\
+    spark.hadoop.fs.s3a.path.style.access       true\n\
+    ' > /opt/spark/conf/spark-defaults.conf
 
 ENTRYPOINT ["/bin/bash", "-c"]:


### PR DESCRIPTION
*Issue #, if available:*

If s3 bucket name contains `dot`(e.g. s3a://my.production.bucket/), it throws the following error. 
```
javax.net.ssl.SSLPeerUnverifiedException: Certificate for <my.production.bucket.s3.amazonaws.com> doesn't match any of the subject alternative names: [*.s3.amazonaws.com, s3.amazonaws.com]
```

See more detail here: https://issues.apache.org/jira/browse/HADOOP-18159

*Description of changes:*

By resolving this issue, enable `spark.hadoop.fs.s3a.path.style.access` in config file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
