### PR TITLE
Move SparkUI Dockerfile to Amazon Linux 2023

### DIFF
--- a/utilities/Spark_UI/Dockerfile
+++ b/utilities/Spark_UI/Dockerfile
@@ -1,8 +1,6 @@
-FROM amazonlinux:2
-FROM amazoncorretto:8
-FROM maven:3.6-amazoncorretto-8
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN yum install -y procps
+RUN dnf --setopt=install_weak_deps=False install -y java-1.8.0-amazon-corretto maven-amazon-corretto8 procps tar gzip && dnf clean all
 
 WORKDIR /tmp/
 ADD pom.xml /tmp


### PR DESCRIPTION
Both Corretto 8 and Maven are packaged in AL2023, so we can just install the packages for them.

*Description of changes:*
I haven't tested this beyond building the container, so it's likely that someone should ensure that the resulting container image still functions as intended.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
