### PR TITLE
Adding sts.assume_role() support to resource_sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv
+**/.venv
+__pycache__

--- a/utilities/resource_sync/README.md
+++ b/utilities/resource_sync/README.md
@@ -21,8 +21,8 @@ You can run this utility in any location where you have Python and the following
 $ sync.py [-h] [--targets TARGETS] [--src-job-names SRC_JOB_NAMES] [--src-database-names SRC_DATABASE_NAMES] [--src-table-names SRC_TABLE_NAMES] [--src-profile SRC_PROFILE] [--src-region SRC_REGION]
                [--src-s3-endpoint-url SRC_S3_ENDPOINT_URL] [--src-sts-endpoint-url SRC_STS_ENDPOINT_URL] [--src-glue-endpoint-url SRC_GLUE_ENDPOINT_URL] [--dst-profile DST_PROFILE]
                [--dst-region DST_REGION] [--dst-s3-endpoint-url DST_S3_ENDPOINT_URL] [--dst-sts-endpoint-url DST_STS_ENDPOINT_URL] [--dst-glue-endpoint-url DST_GLUE_ENDPOINT_URL]
-               [--sts-role-arn STS_ROLE_ARN] [--skip-no-dag-jobs SKIP_NO_DAG_JOBS] [--overwrite-jobs OVERWRITE_JOBS] [--overwrite-databases OVERWRITE_DATABASES] [--overwrite-tables OVERWRITE_TABLES]
-               [--copy-job-script COPY_JOB_SCRIPT] [--config-path CONFIG_PATH] [--skip-errors] [--dryrun] [--skip-prompt] [-v]
+               [--src-role-arn SRC_ROLE_ARN] [--dst-role-arn DST_ROLE_ARN] [--skip-no-dag-jobs SKIP_NO_DAG_JOBS] [--overwrite-jobs OVERWRITE_JOBS] [--overwrite-databases OVERWRITE_DATABASES]
+               [--overwrite-tables OVERWRITE_TABLES] [--copy-job-script COPY_JOB_SCRIPT] [--config-path CONFIG_PATH] [--skip-errors] [--dryrun] [--skip-prompt] [-v]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -53,8 +53,10 @@ optional arguments:
                         Destination endpoint URL for AWS STS.
   --dst-glue-endpoint-url DST_GLUE_ENDPOINT_URL
                         Destination endpoint URL for AWS Glue.
-  --sts-role-arn STS_ROLE_ARN
-                        IAM role arn to be assumed to access destination account resources.
+  --src-role-arn SRC_ROLE_ARN
+                        IAM role ARN to be assumed to access source account resources.
+  --dst-role-arn DST_ROLE_ARN
+                        IAM role ARN to be assumed to access destination account resources.
   --skip-no-dag-jobs SKIP_NO_DAG_JOBS
                         Skip Glue jobs which do not have DAG. (possible values: [true, false]. default: true)
   --overwrite-jobs OVERWRITE_JOBS
@@ -94,12 +96,12 @@ There are two options to configure credentials for accessing resources in target
 
 #### Profile
 
-When you provide `--dst-profile`, this utility uses AWS Named profile set in the option to access resources in the destination account.
+When you provide `--src-profile` or `--dst-profile`, this utility uses AWS Named profile set in the option to access resources in the respective account.
 
 #### STS AssumeRole
 
-When you provide `--sts-role-arn`, this utility assumes the role and use the role to access resources in the destination account.
-You need to create IAM role in the destination account, and configure the trust relationship for the role to allow `AssumeRole` calls from the source account.
+When you provide `--src-role-arn` or `--dst-role-arn`, this utility assumes the role and uses it to access resources in the respective account.
+You need to create IAM roles in the source and/or destination accounts, and configure the trust relationship for the roles to allow `AssumeRole` calls from the account running the script.
 
 ## Examples
 

--- a/utilities/resource_sync/test_sync.py
+++ b/utilities/resource_sync/test_sync.py
@@ -1,0 +1,156 @@
+# Copyright 2019-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import unittest
+from unittest.mock import patch, MagicMock
+import boto3
+from moto import mock_aws
+import sync
+
+
+class TestSync(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_aws = mock_aws()
+        self.mock_aws.start()
+
+        self.glue_client = boto3.client('glue', region_name='us-east-1')
+        self.s3_client = boto3.client('s3', region_name='us-east-1')
+        self.sts_client = boto3.client('sts', region_name='us-east-1')
+
+        # Mock sys.exit to prevent actual exit during tests
+        self.exit_patcher = patch('sys.exit')
+        self.mock_exit = self.exit_patcher.start()
+
+        # Mock args
+        self.args_patcher = patch('sync.args', MagicMock(
+            skip_no_dag_jobs=True,
+            overwrite_databases=True,
+            skip_errors=False,
+            copy_job_script=True,
+            dst_region='us-east-1',
+            targets='job',
+            src_job_names=None,
+            config_path=None
+        ))
+        self.mock_args = self.args_patcher.start()
+
+    def tearDown(self):
+        self.mock_aws.stop()
+        self.exit_patcher.stop()
+        self.args_patcher.stop()
+
+    def test_organize_job_param(self):
+        job = {
+            'Name': 'TestJob',
+            'AllocatedCapacity': 10,
+            'CreatedOn': '2023-01-01',
+            'Command': {
+                'ScriptLocation': 's3://old-bucket/script.py'
+            }
+        }
+        mapping = {
+            's3://old-bucket': 's3://new-bucket'
+        }
+        
+        result = sync.organize_job_param(job, mapping)
+        
+        self.assertNotIn('AllocatedCapacity', result)
+        self.assertNotIn('CreatedOn', result)
+        self.assertEqual(result['Command']['ScriptLocation'], 's3://new-bucket/script.py')
+
+    def test_copy_job_script(self):
+        self.s3_client.create_bucket(Bucket='src-bucket')
+        self.s3_client.put_object(Bucket='src-bucket', Key='script.py', Body='print("Hello")')
+        
+        mock_dst_s3 = MagicMock()
+        mock_dst_s3.meta.client = self.s3_client
+        
+        with patch('sync.src_s3', boto3.resource('s3')), \
+            patch('sync.dst_s3_client', self.s3_client), \
+            patch('sync.dst_s3', mock_dst_s3), \
+            patch('sync.args', MagicMock(dst_region='us-east-1')):
+            sync.copy_job_script('s3://src-bucket/script.py', 's3://dst-bucket/script.py')
+        
+        result = self.s3_client.get_object(Bucket='dst-bucket', Key='script.py')
+        self.assertEqual(result['Body'].read().decode('utf-8'), 'print("Hello")')
+
+    def test_synchronize_job(self):
+        self.glue_client.create_job(
+            Name='TestJob',
+            Role='TestRole',
+            Command={'Name': 'glueetl', 'ScriptLocation': 's3://src-bucket/script.py'}
+        )
+        
+        with patch('sync.src_glue', self.glue_client), \
+             patch('sync.dst_glue', self.glue_client), \
+             patch('sync.copy_job_script'):
+            sync.synchronize_job('TestJob', {})
+        
+        job = self.glue_client.get_job(JobName='TestJob')['Job']
+        self.assertEqual(job['Name'], 'TestJob')
+
+    def test_synchronize_database(self):
+        self.glue_client.create_database(DatabaseInput={'Name': 'TestDB'})
+        
+        with patch('sync.src_glue', self.glue_client), \
+             patch('sync.dst_glue', self.glue_client):
+            sync.synchronize_database({'Name': 'TestDB'}, {})
+        
+        db = self.glue_client.get_database(Name='TestDB')['Database']
+        self.assertEqual(db['Name'], 'TestDB')
+
+    def test_synchronize_table(self):
+        self.glue_client.create_database(DatabaseInput={'Name': 'TestDB'})
+        self.glue_client.create_table(
+            DatabaseName='TestDB',
+            TableInput={
+                'Name': 'TestTable',
+                'StorageDescriptor': {
+                    'Columns': [{'Name': 'col1', 'Type': 'string'}]
+                },
+                'TableType': 'EXTERNAL_TABLE'  # Add this line
+            }
+        )
+        
+        with patch('sync.src_glue', self.glue_client), \
+             patch('sync.dst_glue', self.glue_client):
+            sync.synchronize_table({
+                'Name': 'TestTable',
+                'DatabaseName': 'TestDB',
+                'StorageDescriptor': {
+                    'Columns': [{'Name': 'col1', 'Type': 'string'}]
+                },
+                'TableType': 'EXTERNAL_TABLE'  # Add this line
+            }, {})
+        
+        table = self.glue_client.get_table(DatabaseName='TestDB', Name='TestTable')['Table']
+        self.assertEqual(table['Name'], 'TestTable')
+        self.assertEqual(table['DatabaseName'], 'TestDB')
+
+    def test_main_without_destination_profile(self):
+        with patch('sync.parse_arguments') as mock_parse_args, \
+            patch('sync.boto3.Session') as mock_session, \
+            patch('sync.boto3.client') as mock_client, \
+            patch('sync.load_mapping_config_file', return_value={}), \
+            patch('sync.initialize') as mock_initialize:
+            mock_parse_args.return_value = MagicMock(
+                dst_profile=None,
+                dst_role_arn=None,
+                config_path=None,
+                targets='job',
+                src_job_names=None
+            )
+            mock_session.return_value.get_credentials.return_value = None
+            
+            # Simulate the error condition
+            mock_initialize.side_effect = SystemExit(1)
+            
+            with self.assertRaises(SystemExit) as cm:
+                sync.main()
+            
+            self.assertEqual(cm.exception.code, 1)
+            mock_client.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
*Issue #, if available:* Adding an ability to assume an IAM role in source and destination AWS accounts 

*Description of changes:* Adding `--src-role-arn` and `--dst-role-arn` parameters. The `--sts-role-arn` has been removed. 

*Testing*:

```
cd utilities/resource_sync
python3 -m venv .venv
source .venv/bin/activate
pip install -r requirements.txt

pytest 
```

<img width="1884" alt="image" src="https://github.com/user-attachments/assets/99ab1b0e-4682-443a-acbc-4a8052d23004">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
