### PR TITLE
Adding sts.assume_role() support to resource_sync

### DIFF
--- a/utilities/resource_sync/README.md
+++ b/utilities/resource_sync/README.md
@@ -21,8 +21,9 @@ You can run this utility in any location where you have Python and the following
 $ sync.py [-h] [--targets TARGETS] [--src-job-names SRC_JOB_NAMES] [--src-database-names SRC_DATABASE_NAMES] [--src-table-names SRC_TABLE_NAMES] [--src-profile SRC_PROFILE] [--src-region SRC_REGION]
                [--src-s3-endpoint-url SRC_S3_ENDPOINT_URL] [--src-sts-endpoint-url SRC_STS_ENDPOINT_URL] [--src-glue-endpoint-url SRC_GLUE_ENDPOINT_URL] [--dst-profile DST_PROFILE]
                [--dst-region DST_REGION] [--dst-s3-endpoint-url DST_S3_ENDPOINT_URL] [--dst-sts-endpoint-url DST_STS_ENDPOINT_URL] [--dst-glue-endpoint-url DST_GLUE_ENDPOINT_URL]
-               [--sts-role-arn STS_ROLE_ARN] [--skip-no-dag-jobs SKIP_NO_DAG_JOBS] [--overwrite-jobs OVERWRITE_JOBS] [--overwrite-databases OVERWRITE_DATABASES] [--overwrite-tables OVERWRITE_TABLES]
-               [--copy-job-script COPY_JOB_SCRIPT] [--config-path CONFIG_PATH] [--skip-errors] [--dryrun] [--skip-prompt] [-v]
+               [--sts-role-arn STS_ROLE_ARN] [--src-role-arn SRC_ROLE_ARN] [--dst-role-arn DST_ROLE_ARN] [--skip-no-dag-jobs SKIP_NO_DAG_JOBS] [--overwrite-jobs OVERWRITE_JOBS]
+               [--overwrite-databases OVERWRITE_DATABASES] [--overwrite-tables OVERWRITE_TABLES] [--copy-job-script COPY_JOB_SCRIPT] [--config-path CONFIG_PATH] [--skip-errors] [--dryrun]
+               [--skip-prompt] [-v]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -37,6 +38,8 @@ optional arguments:
                         AWS named profile name for source AWS account.
   --src-region SRC_REGION
                         Source region name.
+  --src-role-arn SRC_ROLE_ARN
+                        IAM role ARN to be assumed to access source account resources.
   --src-s3-endpoint-url SRC_S3_ENDPOINT_URL
                         Source endpoint URL for Amazon S3.
   --src-sts-endpoint-url SRC_STS_ENDPOINT_URL
@@ -55,6 +58,8 @@ optional arguments:
                         Destination endpoint URL for AWS Glue.
   --sts-role-arn STS_ROLE_ARN
                         IAM role arn to be assumed to access destination account resources.
+  --dst-role-arn DST_ROLE_ARN
+                        IAM role ARN to be assumed to access destination account resources.
   --skip-no-dag-jobs SKIP_NO_DAG_JOBS
                         Skip Glue jobs which do not have DAG. (possible values: [true, false]. default: true)
   --overwrite-jobs OVERWRITE_JOBS
@@ -98,8 +103,11 @@ When you provide `--dst-profile`, this utility uses AWS Named profile set in the
 
 #### STS AssumeRole
 
-When you provide `--sts-role-arn`, this utility assumes the role and use the role to access resources in the destination account.
-You need to create IAM role in the destination account, and configure the trust relationship for the role to allow `AssumeRole` calls from the source account.
+When you provide `--src-role-arn`, `--dst-role-arn`, or `--sts-role-arn`, this utility assumes the role and uses it to access resources in the respective account.
+You need to create IAM roles in the source and/or destination accounts, and configure the trust relationship for the roles to allow `AssumeRole` calls from the account running the script.
+
+- Use `--src-role-arn` for accessing the source account resources.
+- Use `--dst-role-arn` or `--sts-role-arn` for accessing the destination account resources. Both serve the same purpose, with `--sts-role-arn` maintained for backward compatibility.
 
 ## Examples
 


### PR DESCRIPTION
*Issue #, if available:* Adding an ability to assume an IAM role in source and destination AWS accounts 

*Description of changes:* Adding `--src-role-arn` and `--dst-role-arn` parameters. The `--sts-role-arn` has been removed. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
