### PR TITLE
Bugfix: resources variable scope

### DIFF
--- a/utilities/resource_sync/sync.py
+++ b/utilities/resource_sync/sync.py
@@ -684,6 +684,8 @@ def synchronize_database(database_name, mapping, database):
 
 
 def main():
+    global resources
+
     if args.config_path:
         logger.debug(f"Loading Mapping config file: {args.config_path}")
         mapping = load_mapping_config_file(args.config_path)


### PR DESCRIPTION
*Issue #, if available:* incorrect scope of the `resources` variable prevents deserialization workflow. 

*Description of changes:* setting up `resources` variable to the global scope allows sync utility work as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
