### PR TITLE
Remove trailing : from ENTRYPOINT

### DIFF
--- a/utilities/Spark_UI/Dockerfile
+++ b/utilities/Spark_UI/Dockerfile
@@ -34,4 +34,4 @@ log4j.appender.console.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %p %c{
 
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk/
 
-ENTRYPOINT ["/bin/bash", "-c"]:
+ENTRYPOINT ["/bin/bash", "-c"]


### PR DESCRIPTION
I'm getting errors like below
```
/opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer: line 1: [/bin/bash,: No such file or directory
```

with command like
```
docker run -itd -e SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS -Dspark.history.fs.logDirectory=s3a://$FILEPATH -Dspark.hadoop.fs.s3a.access.key=$SPARK_AWS_ACCESS_KEY_ID -Dspark.hadoop.fs.s3a.secret.key=$SPARK_AWS_SECRET_ACCESS_KEY -Dspark.hadoop.fs.s3a.session.token=$SPARK_AWS_SESSION_TOKEN -Dspark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider" -p 18080:18080 glue/sparkui:latest "/opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer"
```

Not sure why `:` is added. Removing it solves the issue for me.
