### PR TITLE
Corrected the Glue Workshop link - old link is expired

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can find the AWS Glue open-source Python libraries in a separate repository 
 
 ## Workshops
 
- - [AWS Glue Learning Series](https://catalog.us-east-1.prod.workshops.aws/workshops/3cf2db69-b022-4471-805a-f10daff4676e/en-US)
+ - [AWS Glue Learning Series](https://www.workshops.aws/?tag=Glue)
 
    In this comprehensive series, you'll learn everything from the basics of Glue to advanced optimization techniques.
 


### PR DESCRIPTION
*Issue #, if available:*
The old link for Workshop is not valid anymore , shows Page not found
![image](https://github.com/user-attachments/assets/1ebf3615-a789-43d7-9085-d56f1dcb0ec3)

*Description of changes:*
### Changes done in README
- Corrected the AWS Workshop link for Glue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
