### PR TITLE
Upgrade Spark to 3.5.2 in Spark UI Dockerfile

### DIFF
--- a/utilities/Spark_UI/Dockerfile
+++ b/utilities/Spark_UI/Dockerfile
@@ -1,37 +1,22 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN dnf --setopt=install_weak_deps=False install -y java-1.8.0-amazon-corretto maven-amazon-corretto8 procps tar gzip && dnf clean all
+RUN dnf --setopt=install_weak_deps=False install -y java-17-amazon-corretto maven procps tar gzip && dnf clean all
 
 WORKDIR /tmp/
 ADD pom.xml /tmp
-RUN curl -o ./spark-3.3.0-bin-without-hadoop.tgz https://archive.apache.org/dist/spark/spark-3.3.0/spark-3.3.0-bin-without-hadoop.tgz
-RUN tar -xzf spark-3.3.0-bin-without-hadoop.tgz && \
-    mv spark-3.3.0-bin-without-hadoop /opt/spark && \
-    rm spark-3.3.0-bin-without-hadoop.tgz
+
+ARG SPARK_VERSION=3.5.2
+RUN curl -o ./spark-${SPARK_VERSION}-bin-without-hadoop.tgz https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-without-hadoop.tgz
+RUN tar -xzf spark-${SPARK_VERSION}-bin-without-hadoop.tgz && \
+    mv spark-${SPARK_VERSION}-bin-without-hadoop /opt/spark && \
+    rm spark-${SPARK_VERSION}-bin-without-hadoop.tgz
 RUN mvn dependency:copy-dependencies -DoutputDirectory=/opt/spark/jars/
-RUN rm /opt/spark/jars/jsr305-3.0.0.jar && \
-    rm /opt/spark/jars/jersey-*-1.19.jar && \
-    rm /opt/spark/jars/jackson-dataformat-cbor-2.6.7.jar && \
-    rm /opt/spark/jars/joda-time-2.8.1.jar && \
-    rm /opt/spark/jars/jmespath-java-*.jar && \
-    rm /opt/spark/jars/aws-java-sdk-core-*.jar && \
-    rm /opt/spark/jars/aws-java-sdk-kms-*.jar && \
-    rm /opt/spark/jars/aws-java-sdk-s3-*.jar && \
-    rm /opt/spark/jars/ion-java-1.0.2.jar
 
 RUN echo $'\n\
 spark.eventLog.enabled                      true\n\
 spark.history.ui.port                       18080\n\
 ' > /opt/spark/conf/spark-defaults.conf
 
-RUN echo $'\n\
-log4j.rootLogger = info, console\n\
-log4j.appender.console=org.apache.log4j.ConsoleAppender\n\
-log4j.appender.console.target = System.out\n\
-log4j.appender.console.layout = org.apache.log4j.PatternLayout\n\
-log4j.appender.console.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} %p %c{2}: %m%n\n\
-' > /opt/spark/conf/log4j.properties
-
-ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk/
+ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto/
 
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/utilities/Spark_UI/README.md
+++ b/utilities/Spark_UI/README.md
@@ -21,47 +21,42 @@ If you prefer local access (not to have EC2 instance for Apache Spark history se
 1.  Run commands shown below
     - Set **LOG_DIR** by replacing **s3a://path_to_eventlog** with your event log directory
     - Set **PROFILE_NAME** with your AWS named profile
+    - Set **AWS_REGION** with the S3 bucket region
     ``` 
         $ LOG_DIR="s3a://path_to_eventlog/"
         $ PROFILE_NAME="profile_name"
-        $ docker run -itd -v ~/.aws:/root/.aws -e AWS_PROFILE=$PROFILE_NAME -e SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS -Dspark.history.fs.logDirectory=$LOG_DIR  -Dspark.hadoop.fs.s3a.aws.credentials.provider=com.amazonaws.auth.DefaultAWSCredentialsProviderChain" -p 18080:18080 glue/sparkui:latest "/opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer"
+        $ AWS_REGION="region_name"
+        $ docker run -itd -v ~/.aws:/root/.aws -e AWS_PROFILE=$PROFILE_NAME -e SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS -Dspark.history.fs.logDirectory=$LOG_DIR -Dspark.hadoop.fs.s3a.aws.credentials.provider=software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider -Dspark.hadoop.fs.s3a.endpoint.region=$AWS_REGION" -p 18080:18080 glue/sparkui:latest "/opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer"
     ```
 
 **Using a pair of AWS access key and secret key**
 1.  Run commands shown below
     - Set **LOG_DIR** by replacing **s3a://path_to_eventlog** with your event log directory
     - Set **AWS_ACCESS_KEY_ID** and **AWS_SECRET_ACCESS_KEY** with your valid AWS credential
+    - Set **AWS_REGION** with the S3 bucket region
     ``` 
         $ LOG_DIR="s3a://path_to_eventlog/"
         $ AWS_ACCESS_KEY_ID="AKIAxxxxxxxxxxxx"
         $ AWS_SECRET_ACCESS_KEY="yyyyyyyyyyyyyyy"
-        $ docker run -itd -e SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS -Dspark.history.fs.logDirectory=$LOG_DIR -Dspark.hadoop.fs.s3a.access.key=$AWS_ACCESS_KEY_ID -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_ACCESS_KEY" -p 18080:18080 glue/sparkui:latest "/opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer"
+        $ AWS_REGION="region_name"
+        $ docker run -itd -e SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS -Dspark.history.fs.logDirectory=$LOG_DIR -Dspark.hadoop.fs.s3a.access.key=$AWS_ACCESS_KEY_ID -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_ACCESS_KEY -Dspark.hadoop.fs.s3a.endpoint.region=$AWS_REGION" -p 18080:18080 glue/sparkui:latest "/opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer"
     ```
 
 **Using AWS temporary credentials**
 1.  Run commands shown below
     - Set **LOG_DIR** by replacing **s3a://path_to_eventlog** with your event log directory
     - Set **AWS_ACCESS_KEY_ID**, **AWS_SECRET_ACCESS_KEY**, and **AWS_SESSION_TOKEN** with your valid AWS credential
+    - Set **AWS_REGION** with the S3 bucket region
     ``` 
         $ LOG_DIR="s3a://path_to_eventlog/"
         $ AWS_ACCESS_KEY_ID="ASIAxxxxxxxxxxxx"
         $ AWS_SECRET_ACCESS_KEY="yyyyyyyyyyyyyyy"
         $ AWS_SESSION_TOKEN="zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
-        $ docker run -itd -e SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS -Dspark.history.fs.logDirectory=$LOG_DIR -Dspark.hadoop.fs.s3a.access.key=$AWS_ACCESS_KEY_ID -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_ACCESS_KEY -Dspark.hadoop.fs.s3a.session.token=$AWS_SESSION_TOKEN -Dspark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider" -p 18080:18080 glue/sparkui:latest "/opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer"
+        $ AWS_REGION="region_name"
+        $ docker run -itd -e SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS -Dspark.history.fs.logDirectory=$LOG_DIR -Dspark.hadoop.fs.s3a.access.key=$AWS_ACCESS_KEY_ID -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_ACCESS_KEY -Dspark.hadoop.fs.s3a.session.token=$AWS_SESSION_TOKEN -Dspark.hadoop.fs.s3a.endpoint.region=$AWS_REGION" -p 18080:18080 glue/sparkui:latest "/opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer"
     ```
     
 These configuration parameters come from the [Hadoop-AWS Module](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html). You may need to add specific configuration based on your use case. For example: users in isolated regions will need to configure the `spark.hadoop.fs.s3a.endpoint`.
-
-For Beijing region, add following config:
-
-```
--Dspark.hadoop.fs.s3a.endpoint=s3.cn-north-1.amazonaws.com.cn
-```
-
-For Ningxia region, add following config:
-```
--Dspark.hadoop.fs.s3a.endpoint=s3.cn-northwest-1.amazonaws.com.cn
-```
 
 
 #### View the Spark UI using Docker

--- a/utilities/Spark_UI/pom.xml
+++ b/utilities/Spark_UI/pom.xml
@@ -6,25 +6,24 @@
 	<groupId>com.amazonaws</groupId>
 	<artifactId>HadoopForGlueSparkHistoryServer</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0-SNAPSHOT</version>
+	<version>3.0-SNAPSHOT</version>
 	<name>HadoopForGlueSparkHistoryServer</name>
 	<url>http://maven.apache.org</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jdk.version>1.8</jdk.version>
-		<hadoop.version>3.3.2</hadoop.version>
-		<awssdk.version>1.11.1026</awssdk.version>
-		<httpclient.version>4.5.13</httpclient.version>
-		<jackson.version>2.13.3</jackson.version>
-		<jackson.databind.version>2.13.3</jackson.databind.version>
+		<jdk.version>17</jdk.version>
+		<hadoop.version>3.4.0</hadoop.version>
+		<awssdk.version>2.30.7</awssdk.version>
+		<jackson.version>2.15.2</jackson.version>
+		<jackson.databind.version>2.15.2</jackson.databind.version>
 		<reload4j.version>1.2.25</reload4j.version>
 		<slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>com.amazonaws</groupId>
-				<artifactId>aws-java-sdk-bom</artifactId>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
 				<version>${awssdk.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
@@ -79,33 +78,6 @@
 					<artifactId>jackson-annotations</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-core</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-databind</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.fasterxml.jackson.core</groupId>
-					<artifactId>jackson-annotations</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-s3</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>${httpclient.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Upgrade the libraries in the Spark UI Dockerfile

- Spark 3.3.0 to 3.5.2
- Hadoop 3.3.2 to 3.4.0
- Java 8 to 17
- AWS Java SDK 1.11.1026 to 2.30.7

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
