### PR TITLE
 As Glue limits comments to 255 characters, we may need to truncate them

### DIFF
--- a/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
+++ b/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
@@ -475,6 +475,14 @@ class HiveMetastoreTransformer:
         return self.sql_context.createDataFrame(rdd_result, schema)
 
     def transform_ms_partition_keys(self, ms_partition_keys):
+        def extract_row(row):
+            def truncate(x):
+                return x[:255] if hasattr(x,"__getitem__") else x
+            return (
+                row['PKEY_NAME'],
+                row['PKEY_NAME'],
+                truncate(row['PKEY_COMMENT'])
+            )
         return self.transform_df_with_idx(
             df=ms_partition_keys,
             id_col="TBL_ID",
@@ -487,7 +495,7 @@ class HiveMetastoreTransformer:
                     StructField(name="comment", dataType=StringType()),
                 ]
             ),
-            payload_func=lambda row: (row["PKEY_NAME"], row["PKEY_TYPE"], row["PKEY_COMMENT"]),
+            payload_func=extract_row,
         )
 
     def transform_ms_partition_key_vals(self, ms_partition_key_vals):


### PR DESCRIPTION
This is a PR to merge the original pull request (#38).

Changes added in #38:
- When importing Hive Metastore to Glue Data Catalog, truncate table column's comments to 255 characters to meet Glue limitation.

Changes added in this PR:
- Resolved conflicts for #38
- Added the same truncate logic for partition key column

Tests:
- Tests are written in [this comment](https://github.com/aws-samples/aws-glue-samples/pull/38#issuecomment-2897134613)

- Additional test for partition key:

Steps:
1. Create partitioned table with comments on Hive 3.1.3 Metastore
```
hive> CREATE TABLE
    > comment_test_partitioned (
    >     long_comment int COMMENT "Set up an AWS Glue ETL job which extracts metadata from your Hive metastore (MySQL) and loads it into your AWS Glue Data Catalog. This method requires an AWS Glue connection to the Hive metastore as a JDBC source. An ETL script is provided to extract metadata from the Hive metastore and write it to AWS Glue Data Catalog.",
    >     short_comment int COMMENT "aws-glue-samples",
    >     none_comment int
    > )
    > PARTITIONED BY (
    >     pk int COMMENT "Set up an AWS Glue ETL job which extracts metadata from your Hive metastore (MySQL) and loads it into your AWS Glue Data Catalog. This method requires an AWS Glue connection to the Hive metastore as a JDBC source. An ETL script is provided to extract metadata from the Hive metastore and write it to AWS Glue Data Catalog."
    > );
```

2. Run the job with from-jdbc mode and import the table into Glue Data Catalog.

Results:
With the change in #38, the job failed with this message. (failed at `table.partitionKeys.1.member.comment`)
```
An error occurred while calling o1954.pyWriteDynamicFrame. 1 validation error detected: Value 'Set up an AWS Glue ETL job which extracts metadata from your Hive metastore (MySQL) and loads it into your AWS Glue Data Catalog. This method requires an AWS Glue connection to the Hive metastore as a JDBC source. An ETL script is provided to extract metadata from the Hive metastore and write it to AWS Glue Data Catalog.' at 'table.partitionKeys.1.member.comment' failed to satisfy constraint: Member must have length less than or equal to 255 (Service: Glue, Status Code: 400, Request ID:
```

With this change, the job succeeded and the comment on partition key is also truncated.