### PR TITLE
Add an option to provide parameters by JSON file for hive metastore migration utility

### DIFF
--- a/utilities/Hive_metastore_migration/README.md
+++ b/utilities/Hive_metastore_migration/README.md
@@ -191,17 +191,30 @@ as an Glue ETL job, if AWS Glue can directly connect to your Hive metastore.
 2. Submit the `hive_metastore_migration.py` Spark script to your Spark cluster
    using the following parameters:
 
-   - Set `--config_file` to `<path_to_your_config_yaml_file>` (default path: `artifacts/config.yaml`)
+   - Set `--direction` to `from_metastore`, or omit the argument since
+     `from_metastore` is the default.
 
-   - Provide the following configuration parameters in the configuration yaml file:
-   ```
-    * mode
-    * jdbc-url
-    * jdbc-username
-    * jdbc-password
-    * database-prefix
-    * table-prefix
-   ```
+   - Provide the JDBC connection information through these arguments:
+     `--jdbc-url`, `--jdbc-username`, and `--jdbc-password`.
+
+   - The argument `--output-path` is required. It is either a local file system location
+     or an S3 location. If the output path is a local directory, you can upload the data
+     to an S3 location manually. If it is an S3 path, you need to make sure that the Spark
+     cluster has EMRFS library in its class path. The script will export the metadata to a
+     subdirectory of the output-path you provided.
+     
+   - `--database-prefix` and `--table-prefix` (optional) to set a string prefix that is applied to the 
+     database and table names. They are empty by default. 
+     
+   - Optionally, you can set `--config_file` to `<path_to_your_config_yaml_file>` which contains configuration parameters.
+     - Provide the following configuration parameters in the configuration yaml file:
+        * mode:
+        * jdbc_url:
+        * jdbc_username:
+        * jdbc_password:
+        * database_prefix:
+        * table_prefix:
+        * output_path:
 
    - Example spark-submit command to migrate Hive metastore to S3, tested on EMR-4.7.1:
    ```bash
@@ -210,7 +223,13 @@ as an Glue ETL job, if AWS Glue can directly connect to your Hive metastore.
     spark-submit --driver-class-path $DRIVER_CLASSPATH \
       --jars $MYSQL_JAR_PATH \
       /home/hadoop/hive_metastore_migration.py \
-      --config_file artifacts/config.yaml
+      --mode from-metastore \
+      --jdbc-url jdbc:mysql://metastore.foo.us-east-1.rds.amazonaws.com:3306 \
+      --jdbc-user hive \
+      --jdbc-password myJDBCPassword \
+      --database-prefix myHiveMetastore_ \
+      --table-prefix myHiveMetastore_ \
+      --output-path s3://mybucket/myfolder/
     ```
     
     - If the job finishes successfully, it creates 3 sub-folders in the S3 output path you

--- a/utilities/Hive_metastore_migration/README.md
+++ b/utilities/Hive_metastore_migration/README.md
@@ -206,18 +206,22 @@ as an Glue ETL job, if AWS Glue can directly connect to your Hive metastore.
    - `--database-prefix` and `--table-prefix` (optional) to set a string prefix that is applied to the 
      database and table names. They are empty by default. 
      
-   - Optionally, you can set `--config_file` to `<path_to_your_config_yaml_file>` which contains configuration parameters.
-     - Provide the following configuration parameters in the configuration yaml file:
-        * mode:
-        * jdbc_url:
-        * jdbc_username:
-        * jdbc_password:
-        * database_prefix:
-        * table_prefix:
-        * output_path:
+   - Optionally, you can set `--config_file` to `<path_to_your_config_json_file>` which contains the configuration parameters.
+     - Provide the following configuration parameters in the configuration json file:
+      ```json
+      {
+          "mode": "from-metastore",
+          "jdbc_url": "JDBC URL",
+          "jdbc_username": "JDBC username",
+          "jdbc_password": "JDBC password",
+          "database_prefix": "Database prefix",
+          "table_prefix": "Table prefix",
+          "output_path": "Output local or s3 path"
+      }
+      ```
 
    - Example spark-submit command to migrate Hive metastore to S3, tested on EMR-4.7.1:
-   ```bash
+    ```bash
     MYSQL_JAR_PATH=/usr/lib/hadoop/mysql-connector-java-5.1.42-bin.jar
     DRIVER_CLASSPATH=/home/hadoop/*:/etc/hadoop/conf:/etc/hive/conf:/usr/lib/hadoop-lzo/lib/*:/usr/lib/hadoop/hadoop-aws.jar:/usr/share/aws/aws-java-sdk/*:/usr/share/aws/emr/emrfs/conf:/usr/share/aws/emr/emrfs/lib/*:/usr/share/aws/emr/emrfs/auxlib/*:$MYSQL_JAR_PATH
     spark-submit --driver-class-path $DRIVER_CLASSPATH \
@@ -370,7 +374,7 @@ as an Glue ETL job, if AWS Glue can directly connect to your Hive metastore.
 
 3. Submit the `hive_metastore_migration.py` Spark script to your Spark cluster.
 
-   - Set `--direction` to `to_metastore`.
+   - Set `--mode` to `to_metastore`.
    - Provide the JDBC connection information through the arguments:
      `--jdbc-url`, `--jdbc-username`, and `--jdbc-password`.
    - The argument `--input-path` is required. This can be a local directory or
@@ -392,6 +396,17 @@ as an Glue ETL job, if AWS Glue can directly connect to your Hive metastore.
 
          s3://gluemigrationbucket/export_output/<year-month-day-hour-minute-seconds>/
 
+   - Optionally, you can set `--config_file` to `<path_to_your_config_json_file>` which contains the configuration parameters.
+     - Provide the following configuration parameters in the configuration json file:
+      ```json
+      {
+          "mode": "to-metastore",
+          "jdbc_url": "JDBC URL",
+          "jdbc_username": "JDBC username",
+          "jdbc_password": "JDBC password",
+          "input_path": "Input local  or S3 path"
+      }
+      ```
     	 
 #### AWS Glue Data Catalog to another AWS Glue Data Catalog
  

--- a/utilities/Hive_metastore_migration/README.md
+++ b/utilities/Hive_metastore_migration/README.md
@@ -404,7 +404,7 @@ as an Glue ETL job, if AWS Glue can directly connect to your Hive metastore.
           "jdbc_url": "JDBC URL",
           "jdbc_username": "JDBC username",
           "jdbc_password": "JDBC password",
-          "input_path": "Input local  or S3 path"
+          "input_path": "Input local or S3 path"
       }
       ```
     	 

--- a/utilities/Hive_metastore_migration/README.md
+++ b/utilities/Hive_metastore_migration/README.md
@@ -206,7 +206,7 @@ as an Glue ETL job, if AWS Glue can directly connect to your Hive metastore.
    - `--database-prefix` and `--table-prefix` (optional) to set a string prefix that is applied to the 
      database and table names. They are empty by default. 
      
-   - Optionally, you can set `--config_file` to `<path_to_your_config_json_file>` which contains the configuration parameters.
+   - Optionally, you can set `--config_file` to `<path_to_your_config_json_file>` which contains the configuration parameters. If same parameters are specified in both the configuration json file and the command line, the parameters specified on the command line will be used. 
      - Provide the following configuration parameters in the configuration json file:
       ```json
       {
@@ -396,7 +396,7 @@ as an Glue ETL job, if AWS Glue can directly connect to your Hive metastore.
 
          s3://gluemigrationbucket/export_output/<year-month-day-hour-minute-seconds>/
 
-   - Optionally, you can set `--config_file` to `<path_to_your_config_json_file>` which contains the configuration parameters.
+   - Optionally, you can set `--config_file` to `<path_to_your_config_json_file>` which contains the configuration parameters. If same parameters are specified in both the configuration json file and the command line, the parameters specified on the command line will be used. 
      - Provide the following configuration parameters in the configuration json file:
       ```json
       {

--- a/utilities/Hive_metastore_migration/README.md
+++ b/utilities/Hive_metastore_migration/README.md
@@ -186,35 +186,26 @@ as an Glue ETL job, if AWS Glue can directly connect to your Hive metastore.
 2. Submit the `hive_metastore_migration.py` Spark script to your Spark cluster
    using the following parameters:
 
-   - Set `--direction` to `from_metastore`, or omit the argument since
-     `from_metastore` is the default.
+   - Set `--config_file` to `<path_to_your_config_yaml_file>` (default path: `artifacts/config.yaml`)
 
-   - Provide the JDBC connection information through these arguments:
-     `--jdbc-url`, `--jdbc-username`, and `--jdbc-password`.
+   - Provide the following configuration parameters in the configuration yaml file:
+   ```
+    * mode
+    * jdbc-url
+    * jdbc-username
+    * jdbc-password
+    * database-prefix
+    * table-prefix
+   ```
 
-   - The argument `--output-path` is required. It is either a local file system location
-     or an S3 location. If the output path is a local directory, you can upload the data
-     to an S3 location manually. If it is an S3 path, you need to make sure that the Spark
-     cluster has EMRFS library in its class path. The script will export the metadata to a
-     subdirectory of the output-path you provided.
-     
-   - `--database-prefix` and `--table-prefix` (optional) to set a string prefix that is applied to the 
-     database and table names. They are empty by default. 
-     
    - Example spark-submit command to migrate Hive metastore to S3, tested on EMR-4.7.1:
-    ```bash
+   ```bash
     MYSQL_JAR_PATH=/usr/lib/hadoop/mysql-connector-java-5.1.42-bin.jar
     DRIVER_CLASSPATH=/home/hadoop/*:/etc/hadoop/conf:/etc/hive/conf:/usr/lib/hadoop-lzo/lib/*:/usr/lib/hadoop/hadoop-aws.jar:/usr/share/aws/aws-java-sdk/*:/usr/share/aws/emr/emrfs/conf:/usr/share/aws/emr/emrfs/lib/*:/usr/share/aws/emr/emrfs/auxlib/*:$MYSQL_JAR_PATH
     spark-submit --driver-class-path $DRIVER_CLASSPATH \
       --jars $MYSQL_JAR_PATH \
       /home/hadoop/hive_metastore_migration.py \
-      --mode from-metastore \
-      --jdbc-url jdbc:mysql://metastore.foo.us-east-1.rds.amazonaws.com:3306 \
-      --jdbc-user hive \
-      --jdbc-password myJDBCPassword \
-      --database-prefix myHiveMetastore_ \
-      --table-prefix myHiveMetastore_ \
-      --output-path s3://mybucket/myfolder/
+      --config_file artifacts/config.yaml
     ```
     
     - If the job finishes successfully, it creates 3 sub-folders in the S3 output path you

--- a/utilities/Hive_metastore_migration/artifacts/config.yaml
+++ b/utilities/Hive_metastore_migration/artifacts/config.yaml
@@ -1,0 +1,8 @@
+mode:
+jdbc-url:
+jdbc-username:
+jdbc-password:
+database-prefix:
+table-prefix:
+output-path:
+input_path:

--- a/utilities/Hive_metastore_migration/artifacts/config.yaml
+++ b/utilities/Hive_metastore_migration/artifacts/config.yaml
@@ -1,8 +1,0 @@
-mode:
-jdbc-url:
-jdbc-username:
-jdbc-password:
-database-prefix:
-table-prefix:
-output-path:
-input_path:

--- a/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
+++ b/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
@@ -9,7 +9,6 @@ import re
 # except for python 2.7 standard library and Spark 2.1
 import sys
 from datetime import datetime, timedelta, tzinfo
-import yaml
 from time import localtime, strftime
 from types import MethodType
 
@@ -1583,7 +1582,7 @@ def get_options(parser, args):
 def parse_arguments(args):
     """
     parse arguments for the metastore migration.
-    If a yaml file is provided, it will override any parameters specified on the command line.
+    If a json file is provided, it will override any parameters specified on the command line.
     ----------
     Return:
         Dictionary of config options
@@ -1597,15 +1596,15 @@ def parse_arguments(args):
     parser.add_argument("-t", "--table-prefix", required=False, help="Optional prefix for table name in Glue DataCatalog")
     parser.add_argument("-o", "--output-path", required=False, help="Output path, either local directory or S3 path")
     parser.add_argument("-i", "--input_path", required=False, help="Input path, either local directory or S3 path")
-    parser.add_argument("-f", "--config_file", required=False, help="yaml configuration file path to read migration arguments from.")
+    parser.add_argument("-f", "--config_file", required=False, help="json configuration file path to read migration arguments from.")
     options = get_options(parser, args)
 
     if options.get("config_file") is not None:
-        # parse yaml config file if provided
+        # parse json config file if provided
         config_file_path = options["config_file"]
-        logger.info(f"config_file provided. Parsing arguments from {options["config_file"]}")
-        with open(config_file_path, 'r') as yaml_file_stream:
-            config_options = yaml.load(yaml_file_stream, Loader=yaml.FullLoader)
+        logger.info(f"config_file provided. Parsing arguments from {config_file_path}")
+        with open(config_file_path, 'r') as json_file_stream:
+            config_options = json.load(json_file_stream)
         options = {**options, **config_options}
 
     if options.get("mode") is None:

--- a/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
+++ b/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
@@ -1582,7 +1582,7 @@ def get_options(parser, args):
 def parse_arguments(args):
     """
     parse arguments for the metastore migration.
-    If a json file is provided, it will override any parameters specified on the command line.
+    If arguments are provided by both a json config file and command line, command line arguments will override any parameters specified on the json file.
     ----------
     Return:
         Dictionary of config options
@@ -1605,7 +1605,13 @@ def parse_arguments(args):
         logger.info(f"config_file provided. Parsing arguments from {config_file_path}")
         with open(config_file_path, 'r') as json_file_stream:
             config_options = json.load(json_file_stream)
-        options = {**options, **config_options}
+        
+        # merge options. command line options are prioritized.
+        for key in config_options:
+            if not options.get(key):
+                options[key] = config_options[key]
+            elif options[key] is None:
+                options[key] = config_options[key]
 
     if options.get("mode") is None:
         raise AssertionError("--mode options is required: either from_metastore or to_metastore")

--- a/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
+++ b/utilities/Hive_metastore_migration/src/hive_metastore_migration.py
@@ -14,6 +14,7 @@
 # except for python 2.7 standard library and Spark 2.1
 import sys
 import argparse
+import yaml
 import re
 import logging
 from time import localtime, strftime
@@ -1398,6 +1399,39 @@ def parse_arguments(args):
     return options
 
 
+def parse_arguments_from_yaml_file(args):
+    """
+    This function accepts the path to a config file
+    and extracts the needed arguments for the metastore migration
+    ----------
+    Return:
+        Dictionary of config options
+    """
+    parser = argparse.ArgumentParser(prog=args[0])
+    parser.add_argument('-f', '--config_file', required=True, default='artifacts/config.yaml`', help='Provide yaml configuration file path to read migration arguments from. Default path: `artifacts/config.yaml`')
+    options = get_options(parser, args)
+    config_file_path = options['config_file']
+    ## read the yaml file
+    with open(config_file_path, 'r') as yaml_file_stream:
+        config_options = yaml.load(yaml_file_stream)
+
+    if config_options['mode'] == FROM_METASTORE:
+        validate_options_in_mode(
+            options=config_options, mode=FROM_METASTORE,
+            required_options=['output_path'],
+            not_allowed_options=['input_path']
+        )
+    elif config_options['mode'] == TO_METASTORE:
+        validate_options_in_mode(
+            options=config_options, mode=TO_METASTORE,
+            required_options=['input_path'],
+            not_allowed_options=['output_path']
+        )
+    else:
+        raise AssertionError('unknown mode ' + options['mode'])
+
+    return config_options
+
 def get_spark_env():
     conf = SparkConf()
     sc = SparkContext(conf=conf)
@@ -1501,7 +1535,10 @@ def validate_aws_regions(region):
 
 
 def main():
-    options = parse_arguments(sys.argv)
+    # options = parse_arguments(sys.argv)
+
+    ## This now reads options from path to config yaml file
+    options = parse_arguments_from_yaml_file(sys.argv)
 
     connection = {
         'url': options['jdbc_url'],


### PR DESCRIPTION
This is a PR to merge #13

## Changes made in #13
- The parameters are passed by yaml config file for `from_metastore` and `to_metastore` options. This prevents JDBC password exposure on spark-submit command.

## Changes added in this PR
- Made specifying a config file optional, so that we can keep using command line parameters depending on users' needs.
- Changed the config file format from yaml to json. This change avoids the necessity of installing PyYAML on Glue 5.0 job. (PyYAML is provided until Glue 4.0. [doc](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-python-libraries.html#glue-modules-provided))

## Tests
### Testing with a config file
#### Case 1: run with expected config file
1. Launched EMR 7.9 cluster
2. Create a config file
```config.json
{
    "mode": "from-metastore",
    "jdbc_url": "jdbc:mysql://**:3306",
    "jdbc_username": "hive",
    "jdbc_password": "password",
    "database_prefix": "dbpre_",
    "table_prefix": "tablepre_",
    "output_path": "s3://path"
}
```
3. Run hive_metastore_migration.py
```
$ spark-submit \
  --jars $MYSQL_JAR_PATH \
  /home/hadoop/hive_metastore_migration.py \
 --config_file config.json
```

Result: Succeeded and exported metastore to S3.

#### Case 2: run with a config file and lack mandatory parameter
1. Launched EMR 7.9 cluster
2. Create a config file (without `jdbc_password`)
```config.json
{
    "mode": "from-metastore",
    "jdbc_url": "jdbc:mysql://**:3306",
    "jdbc_username": "hive",
    "output_path": "s3://path"
}
```
3. Run hive_metastore_migration.py
```
$ spark-submit \
  --jars $MYSQL_JAR_PATH \
  /home/hadoop/hive_metastore_migration.py \
 --config_file config.json
```

Result: failed the command with the following message as expected.
```
2025-05-28 07:53:52,041 - root - INFO - config_file provided. Parsing arguments from config.json
Traceback (most recent call last):
  File "/home/hadoop/hive_metastore_migration.py", line 1775, in <module>
    main()
  File "/home/hadoop/hive_metastore_migration.py", line 1757, in main
    options = parse_arguments(sys.argv)
  File "/home/hadoop/hive_metastore_migration.py", line 1613, in parse_arguments
    validate_options_in_mode(
  File "/home/hadoop/hive_metastore_migration.py", line 1691, in validate_options_in_mode
    raise AssertionError("Option %s is required for mode %s" % (option, mode))
AssertionError: Option jdbc_password is required for mode from-metastore
```

### Case 3: run with a config file and command line parameter
1. Launched EMR 7.9 cluster
2. Create a config file
```config.json
{
    "mode": "from-metastore",
    "jdbc_url": "jdbc:mysql://**:3306",
    "jdbc_username": "hive",
    "jdbc_password": "password",
    "database_prefix": "dbpre_",
    "table_prefix": "tablepre_",
    "output_path": "s3://path"
}
```
3. Run hive_metastore_migration.py with `--database-prefix`
```
$ spark-submit \
  --jars $MYSQL_JAR_PATH \
  /home/hadoop/hive_metastore_migration.py \
 --database-prefix dbpre_updated_ \
 --config_file config.json
```

Result: successfully metastore was exported, and --database-prefix was overriden by command line config.


### Testing without a config file (regression)
#### case 4: run with command line parameters
1. Launched EMR 7.9 cluster
2. Run hive_metastore_migration.py
```
spark-submit \
  --jars $MYSQL_JAR_PATH \
  /home/hadoop/hive_metastore_migration.py \
  --mode from-metastore \
  --jdbc-url jdbc:mysql://**:3306 \
  --jdbc-user hive \
  --jdbc-password ** \
  --output-path s3://**/
```

Result: the job succeeded.

#### case 5: run with from-s3 mode
1. Run import_into_datacatalog.py with from-s3 mode on Glue 5.0

Result: Succeeded (importing updated hive_metastore_migration.py didn't affect the behavior)

#### case 6: run with to-s3 mode
1. Run export_from_datacatalog.py with to-s3 mode on Glue 3.0

Result: Succeeded (importing updated hive_metastore_migration.py didn't affect the behavior)