### PR TITLE
Fix table search in federated catalog

### DIFF
--- a/examples/transforms/GlueDQResultToDataZonePublisher/post_dq_results_to_datazone.py
+++ b/examples/transforms/GlueDQResultToDataZonePublisher/post_dq_results_to_datazone.py
@@ -178,7 +178,7 @@ def search_asset_id(datazone, dzDomain, tableName, schemaName, maxResults: int) 
                 forms_dict['RedshiftTableForm']['schemaName'] == schemaName and
                 forms_dict['RedshiftTableForm']['tableName'] == tableName) or \
                 ('GlueTableForm' in forms_dict and
-                f"table/{schemaName}/{tableName}" in forms_dict['GlueTableForm']['tableArn']):
+                f"{schemaName}/{tableName}" in forms_dict['GlueTableForm']['tableArn']):
                 entity_identifier=item['assetListing']['entityId']
                 get_logger().info(f"DZ Asset Id: {entity_identifier_list}")
                 entity_identifier_list.append(entity_identifier)


### PR DESCRIPTION
*Fix table search in federated catalog:*

When using a federated catalog, the table arn search doesn't work because of the 'table' prefix which is hardcoded in the script. By removing it, the search capability worked and I was able to find the asset on SMUS and update its quality results.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
