### PR TITLE
chore: upgrade Spark version from 3.5.2 to 3.5.7

### DIFF
--- a/utilities/Spark_UI/Dockerfile
+++ b/utilities/Spark_UI/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf --setopt=install_weak_deps=False install -y java-17-amazon-corretto mave
 WORKDIR /tmp/
 ADD pom.xml /tmp
 
-ARG SPARK_VERSION=3.5.2
+ARG SPARK_VERSION=3.5.7
 RUN curl -o ./spark-${SPARK_VERSION}-bin-without-hadoop.tgz https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-without-hadoop.tgz
 RUN tar -xzf spark-${SPARK_VERSION}-bin-without-hadoop.tgz && \
     mv spark-${SPARK_VERSION}-bin-without-hadoop /opt/spark && \


### PR DESCRIPTION
Updates the Spark version in `utilities/Spark_UI/Dockerfile` to use the latest patch version 3.5.7. This provides bug fixes and improvements while maintaining compatibility. Specifically, version 3.5.7 includes fixes for https://issues.apache.org/jira/browse/SPARK-49872 which prevents larger Glue Spark UI logs from being loaded successfully. 